### PR TITLE
fedpkg-sync-build-all-branches: use -X with fedrq

### DIFF
--- a/bin/fedpkg-sync-build-all-branches.sh
+++ b/bin/fedpkg-sync-build-all-branches.sh
@@ -32,7 +32,7 @@ impact_check () {
     do
         echo ">> Checking update impact using fedrq for ${branch}"
         echo ">> The following packages will be affected. Please ensure that they do not break as a result of this update:"
-        fedrq whatrequires-src -b "${branch}" -F breakdown "${PACKAGE_NAME}"
+        fedrq whatrequires-src -b "${branch}" -F breakdown -X "${PACKAGE_NAME}"
 done
 }
 


### PR DESCRIPTION
You should use the -X / --exclude-subpackages flag here so "${PACKAGE_NAME}" itself doesn't show up in the results if one of its subpackages depends on another.